### PR TITLE
Allowed other content-types in DeployedModel

### DIFF
--- a/skater/model/deployed_model.py
+++ b/skater/model/deployed_model.py
@@ -93,7 +93,7 @@ class DeployedModel(ModelType):
         """
         Just use the function itself for predictions
         """
-        return requests.post(self.uri, json=data, **self.request_kwargs)
+        return requests.post(self.uri, data=data, **self.request_kwargs)
 
 
     @staticmethod
@@ -138,7 +138,7 @@ class DeployedModel(ModelType):
         predictions: arraytype
         """
         query = input_formatter(data)
-        response = requests.post(uri, json=query, **request_kwargs)
+        response = requests.post(uri, data=query, **request_kwargs)
         results = output_formatter(response)
         if transformer:
             results = transformer(results)


### PR DESCRIPTION
The changes undo an initial mistake in the code where the function DeployedModel was accepting keyword arguments to specify the content type and headers, but overrode it in lines 96 and 141 to content-type as application/json.

You can validate the changes by passing a 'x-www-form-urlencoded' data to the DeployedModel function. The original code would have overwritten the content-type to application/json but the changes will send the data as x-www-form-urlencoded data. 

Signed-off by: Suprit M Kulkarni <supritmekulkarni@gmail.com> 