### PR TITLE
Changes in test case

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -77,7 +77,7 @@ def setup_package():
         include_package_data=True,
         install_requires=[
             'scikit-learn>=0.19',
-            'scikit-image==0.14',
+            'scikit-image>=0.14',
             'pandas>=0.22.0',
             'lime>=0.1.1.21',
             'requests',

--- a/skater/core/local_interpretation/dnni/deep_interpreter.py
+++ b/skater/core/local_interpretation/dnni/deep_interpreter.py
@@ -43,7 +43,7 @@ class DeepInterpreter(object):
     Parameters
     ----------
     graph : tensorflow.Graph instance
-    session : tensorflow.Session to execute the graph(default session: tf.get_default_session())
+    session : tensorflow.Session to execute the graph(default session: tf.compat.v1.get_default_session)
     log_level : int (default: _WARNING)
         The log_level could be adjusted to other values as well. Check here `./skater/util/logger.py`
 
@@ -56,7 +56,7 @@ class DeepInterpreter(object):
     """
     __name__ = "DeepInterpreter"
 
-    def __init__(self, graph=None, session=tf.get_default_session(), log_level=_WARNING):
+    def __init__(self, graph=None, session=tf.compat.v1.get_default_session, log_level=_WARNING):
         self.logger = build_logger(log_level, __name__)
         self.relevance_type = None
         self.use_case_str = None

--- a/skater/tests/test_data.py
+++ b/skater/tests/test_data.py
@@ -5,7 +5,7 @@ import pandas as pd
 from numpy.testing import assert_array_equal
 
 from skater.data import DataManager
-from arg_parser import arg_parse, create_parser
+from .arg_parser import arg_parse, create_parser
 
 
 class TestData(unittest.TestCase):

--- a/skater/tests/test_dnni.py
+++ b/skater/tests/test_dnni.py
@@ -1,6 +1,7 @@
 import unittest
 
 import keras
+import tensorflow as tf
 from keras.datasets import mnist
 from keras.models import Sequential, Model, load_model, model_from_yaml
 from keras import backend as K
@@ -79,7 +80,7 @@ class TestDNNI(unittest.TestCase):
 
     def test_deep_interpreter_cnn(self):
         K.set_learning_phase(0)
-        with DeepInterpreter(session=K.get_session()) as di:
+        with DeepInterpreter(session=tf.compat.v1.keras.backend.get_session()) as di:
             # 1. Load the persisted model
             # 2. Retrieve the input tensor from the loaded model
 

--- a/skater/tests/test_partial_dependence.py
+++ b/skater/tests/test_partial_dependence.py
@@ -10,7 +10,7 @@ from functools import partial
 
 from skater.core.explanations import Interpretation
 from skater.util import exceptions
-from arg_parser import create_parser
+from .arg_parser import create_parser
 from skater.model import InMemoryModel, DeployedModel
 from skater.util.dataops import MultiColumnLabelBinarizer
 from skater.core.global_interpretation.partial_dependence import PartialDependence


### PR DESCRIPTION
Changes in test case
case 1: To use with latest tensorflow version 2

Since in the readme its not specified in general which version of tensorflow to use. Faced below issue
AttributeError: module 'tensorflow' has no attribute 'get_default_session' as I had latest version of tensorflow. So either we can specifically mention the required version of tensorflow to 1.15 or we can update the test cases

Case 2: Solve the import validate length issue in scikit image