### PR TITLE
Enable skater support for scikit-learn above 0.21.3 

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -88,7 +88,8 @@ def setup_package():
             'Jinja2>=2.10.1',
             'pydotplus>=2.0.2',
             'plotly>=3.2.0',
-            'bs4'],
+            'bs4',
+            'six'],
         extras_require={
             'all': 'matplotlib'},
         zip_safe=False)

--- a/skater/core/global_interpretation/tree_surrogate.py
+++ b/skater/core/global_interpretation/tree_surrogate.py
@@ -157,7 +157,7 @@ class TreeSurrogate(object):
                                          max_features=max_features, random_state=seed,
                                          max_leaf_nodes=max_leaf_nodes,
                                          min_impurity_decrease=min_impurity_decrease,
-                                         class_weight=class_weight, presort=presort)
+                                         class_weight=class_weight)
         elif self.__model_type == 'regressor':
             est = DecisionTreeRegressor(splitter=self.splitter, max_depth=None,
                                         min_samples_split=min_samples_split,
@@ -165,7 +165,7 @@ class TreeSurrogate(object):
                                         min_weight_fraction_leaf=min_weight_fraction_leaf,
                                         max_features=max_features,
                                         random_state=seed, max_leaf_nodes=max_leaf_nodes,
-                                        min_impurity_split=min_impurity_split, presort=presort)
+                                        min_impurity_split=min_impurity_split)
         else:
             raise exceptions.ModelError("Model type not supported. Supported options types{'classifier', 'regressor'}")
         self.__model = est

--- a/skater/core/visualizer/tree_visualizer.py
+++ b/skater/core/visualizer/tree_visualizer.py
@@ -1,4 +1,3 @@
-from sklearn.externals.six import StringIO
 from sklearn.tree import export_graphviz
 import numpy as np
 import pydotplus
@@ -47,6 +46,10 @@ def _get_colors(num_classes, random_state=1):
 
 def _generate_graph(est, est_type='classifier', classes=None, features=None,
                     enable_node_id=True, coverage=True):
+    import six
+    import sys
+    sys.modules['sklearn.externals.six'] = six
+    from sklearn.externals.six import StringIO
     dot_data = StringIO()
     # class names are needed only for "Classification" for "Regression" it is set to None
     c_n = classes if est_type == 'classifier' else None

--- a/skater/core/visualizer/tree_visualizer.py
+++ b/skater/core/visualizer/tree_visualizer.py
@@ -1,7 +1,7 @@
 from sklearn.tree import export_graphviz
 import numpy as np
 import pydotplus
-
+from six import StringIO
 from skater.util import exceptions
 try:
     import matplotlib.pyplot as plt
@@ -46,10 +46,6 @@ def _get_colors(num_classes, random_state=1):
 
 def _generate_graph(est, est_type='classifier', classes=None, features=None,
                     enable_node_id=True, coverage=True):
-    import six
-    import sys
-    sys.modules['sklearn.externals.six'] = six
-    from sklearn.externals.six import StringIO
     dot_data = StringIO()
     # class names are needed only for "Classification" for "Regression" it is set to None
     c_n = classes if est_type == 'classifier' else None


### PR DESCRIPTION
Fixing the errors skater throws with latest scikit-learn version 1.0.2 as of now.